### PR TITLE
Buf reads

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -192,8 +192,6 @@ func (b *Backup) Run() error {
 		// The number of individual blocks in the buffer.
 		bufEntries := len(blockBuf) / b.Config.BlockSize
 
-		fmt.Printf("iteration: %d, bufEntries: %d, bufCapacity: %d\n", iteration, bufEntries, bufCapacity)
-
 		// Insert the block positions into the database and write the blocks to the backup file.
 		hashMap, err := b.writeBlocks(targetFile, iteration, bufEntries, bufCapacity, blockBuf)
 		if err != nil {

--- a/restore_test.go
+++ b/restore_test.go
@@ -92,7 +92,7 @@ func TestFullRestoreFromDifferential(t *testing.T) {
 		OutputFormat:    BackupOutputFormatFile,
 		OutputDirectory: "backups",
 		BlockSize:       1048576,
-		BlockBufferSize: 7,
+		BlockBufferSize: 3,
 	}
 
 	b, err := NewBackup(cfg)


### PR DESCRIPTION

```
=============Info=================
Backup Duration: 956.087827ms
Backup file: ./backups/data_0-app_543140_repl_test_replica_15213164585027598_full_1708042933258
Backup size 14.0 MiB
Source device size: 3.0 GiB
Space saved: 3.0 GiB
Blocks evaluated: 3072
Blocks written: 14
==================================
```